### PR TITLE
Added a method to allow a user to hide Previous/Next controls.

### DIFF
--- a/BSKeyboardControls/BSKeyboardControls.h
+++ b/BSKeyboardControls/BSKeyboardControls.h
@@ -71,6 +71,11 @@ typedef enum
  */
 - (void)reloadTextFields;
 
+/*
+ * Allow hiding of previous / next buttons
+ */
+- (void)hidePrevNextButtons: (BOOL)isHidden;
+
 @end
 
 /* Delegation methods */

--- a/BSKeyboardControls/BSKeyboardControls.m
+++ b/BSKeyboardControls/BSKeyboardControls.m
@@ -175,6 +175,12 @@ enum {
 	}
 }
 
+/* Previous / Next controls are shown by default, but may be hidden */
+- (void)hidePrevNextButtons: (BOOL)isHidden
+{
+    self.segmentedPreviousNext.hidden = isHidden;
+}
+
 #pragma mark -
 #pragma mark Getters and Setters
 


### PR DESCRIPTION
Sometimes a user may want to hide the previous / next controls, and just have the done button. I've written a simple method to achieve this. The controls are shown by default so a user has to call [self.keyboardControls hidePrevNextButtons: YES]; to hide them.
