### PR TITLE
Changed strong delegate to weak delegate

### DIFF
--- a/BSKeyboardControls/BSKeyboardControls.h
+++ b/BSKeyboardControls/BSKeyboardControls.h
@@ -23,7 +23,7 @@ typedef enum
 /*
  * Delegate
  */
-@property (nonatomic, strong) id <BSKeyboardControlsDelegate> delegate;
+@property (nonatomic, weak) id <BSKeyboardControlsDelegate> delegate;
 
 /*
  * Text fields the controls should work on


### PR DESCRIPTION
Delegates should be declared as weak when using ARC, otherwise it can lead to retain cycles.
