### PR TITLE
Podspec file must require ARC

### DIFF
--- a/BSKeyboardControls.podspec
+++ b/BSKeyboardControls.podspec
@@ -6,6 +6,7 @@ Pod::Spec.new do |s|
   s.license      = 'MIT'
   s.author       = { "Simon Støvring" => "simonstoevring@gmail.com" }
   s.source       = { :git => "https://github.com/simonbs/BSKeyboardControls.git", :tag => "v1.1" }
+  s.requires_arc = true
   s.platform     = :ios
   s.source_files = 'BSKeyboardControls/BSKeyboardControls.{h,m}'
 end


### PR DESCRIPTION
You can view the memory leak warnings with the Static Analyzer. The podspec must specify the files be compiled using ARC.
