### PR TITLE
Allow to set the activeField to nil.

### DIFF
--- a/BSKeyboardControls/BSKeyboardControls.m
+++ b/BSKeyboardControls/BSKeyboardControls.m
@@ -84,7 +84,7 @@
 {
     if (activeField != _activeField)
     {
-        if (!activeField || [self.fields containsObject:activeField] ||)
+        if (!activeField || [self.fields containsObject:activeField])
         {
             _activeField = activeField;
         


### PR DESCRIPTION
This is with the purpose of the user having an easy reference if a `textField` is selected (and which one) or not. 

Having it on `nil` doesn't affects `BSKeyboardControls` since a new `activeField` will be set when a text field is selected again.
