### PR TITLE
Fix 2 bugs appeared in iOS7: Not scrolling properly & Dismiss keyboard not working with UITextView

### DIFF
--- a/Example/Example/ViewController.m
+++ b/Example/Example/ViewController.m
@@ -9,6 +9,8 @@
 #import "ViewController.h"
 #import "BSKeyboardControls.h"
 
+#define SYSTEM_VERSION_LESS_THAN(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
+
 static NSString *kDeveloperUrl = @"http://twitter.com/simonbs";
 
 enum
@@ -91,15 +93,23 @@ enum
 #pragma mark Keyboard Controls Delegate
 
 - (void)keyboardControls:(BSKeyboardControls *)keyboardControls selectedField:(UIView *)field inDirection:(BSKeyboardControlsDirection)direction
-{
-    UIView *view = keyboardControls.activeField.superview.superview;
+{    
+    UIView *view;
+    
+    if (SYSTEM_VERSION_LESS_THAN(@"7.0")) {
+        view = field.superview.superview;
+    } else {
+        view = field.superview.superview.superview;
+    }
+    
     [self.tableView scrollRectToVisible:view.frame animated:YES];
 }
 
 - (void)keyboardControlsDonePressed:(BSKeyboardControls *)keyboardControls
 {
-    [keyboardControls.activeField resignFirstResponder];
+    [self.view endEditing:YES];
 }
+
 
 #pragma mark -
 #pragma mark Table View Delegate


### PR DESCRIPTION
## Not scrolling properly

View hierarchy of UITableViewCell is different in iOS7.
Apple added `UITableViewCellScrollView` between `UITableViewCellContentView` and `UITableViewCell`, so we should add one more `[view superview]` to get the `UITableViewCell` which `activeField` belongs to.
## Dismiss keyboard not working with UITextView

`resignFirstResponder` doesn't work with `UITextView` to dismiss keyboard in iOS7, replace it with `[view endEditing:YES]` to fix it.
