### PR TITLE
Add iOS 7 arrows to replace iOS 6 prev/next

### DIFF
--- a/BSKeyboardControls/BSKeyboardControls.h
+++ b/BSKeyboardControls/BSKeyboardControls.h
@@ -68,17 +68,17 @@ typedef enum
 @property (nonatomic, strong) UIColor *barTintColor;
 
 /**
- *  Tint color of the segmented control.
+ *  Tint color of the segmented control. iOS 6 Only.
  */
 @property (nonatomic, strong) UIColor *segmentedControlTintControl;
 
 /**
- *  Title of the previous button. If this is not set, a default localized title will be used.
+ *  Title of the previous button. If this is not set, a default localized title will be used. iOS 6 Only.
  */
 @property (nonatomic, strong) NSString *previousTitle;
 
 /**
- *  Title of the next button. If this is not set, a default localized title will be used.
+ *  Title of the next button. If this is not set, a default localized title will be used. iOS 6 Only.
  */
 @property (nonatomic, strong) NSString *nextTitle;
 


### PR DESCRIPTION
In iOS 7 a left and right arrow replace the next and previous buttons as is seen in the Safari form fill keyboard. This PR replace the prev/next buttons with arrows only under iOS 7 to resolve #23.
