### PR TITLE
Define BSKeyboardControl using NS_OPTIONS and BSKeyboardControlsDirec…

### DIFF
--- a/BSKeyboardControls/BSKeyboardControls.h
+++ b/BSKeyboardControls/BSKeyboardControls.h
@@ -11,21 +11,21 @@
 /**
  *  Available controls.
  */
-typedef enum
+typedef NS_OPTIONS(NSUInteger, BSKeyboardControl)
 {
     BSKeyboardControlPreviousNext = 1 << 0,
     BSKeyboardControlDone = 1 << 1
-} BSKeyboardControl;
+};
 
 /**
  *  Directions in which the fields can be selected.
  *  These are relative to the active field.
  */
-typedef enum
+typedef NS_ENUM(NSUInteger, BSKeyboardControlsDirection)
 {
     BSKeyboardControlsDirectionPrevious = 0,
     BSKeyboardControlsDirectionNext
-} BSKeyboardControlsDirection;
+};
 
 @protocol BSKeyboardControlsDelegate;
 


### PR DESCRIPTION
…tion using NS_ENUM to make them usable in Swift.

This makes us able to write code like this in Swift...

keyboardControls.visibleControls = [.PreviousNext, .Done]