### PR TITLE
Add resources entry to podspec

### DIFF
--- a/BSKeyboardControls.podspec
+++ b/BSKeyboardControls.podspec
@@ -1,13 +1,14 @@
 # coding: utf-8
 Pod::Spec.new do |s|
   s.name         = "BSKeyboardControls"
-  s.version      = "2.3"
+  s.version      = "2.3.1"
   s.summary      = "Put controls above the keyboard on your iPhone or iPad app."
   s.homepage     = "https://github.com/simonbs/BSKeyboardControls"
   s.license      = 'MIT'
   s.author       = { "Simon Støvring" => "simonstoevring@gmail.com" }
-  s.source       = { :git => "https://github.com/simonbs/BSKeyboardControls.git", :tag => "v2.3" }
+  s.source       = { :git => "https://github.com/simonbs/BSKeyboardControls.git", :tag => "v2.3.1" }
   s.requires_arc = true
   s.platform     = :ios, '5.0'
   s.source_files = 'BSKeyboardControls/BSKeyboardControls.{h,m}'
+  s.resources    = 'BSKeyboardControls/*.lproj/*.strings'
 end


### PR DESCRIPTION
Now localization files exist only in the example project.

They aren't copied while 'pod install'.

So, this PR fixes that.

P.S.
Please remember to post the new podspec in Cocoapods specs repository. Now there is only version 2.2 while in your repo version is already 2.3. 